### PR TITLE
fix: jar name

### DIFF
--- a/pnx/loader/src/main/java/me/lucko/luckperms/nukkit/loader/NukkitLoaderPlugin.java
+++ b/pnx/loader/src/main/java/me/lucko/luckperms/nukkit/loader/NukkitLoaderPlugin.java
@@ -30,7 +30,7 @@ import me.lucko.luckperms.common.loader.JarInJarClassLoader;
 import me.lucko.luckperms.common.loader.LoaderBootstrap;
 
 public class NukkitLoaderPlugin extends PluginBase {
-    private static final String JAR_NAME = "luckperms-nukkit.jarinjar";
+    private static final String JAR_NAME = "luckperms-pnx.jarinjar";
     private static final String BOOTSTRAP_CLASS = "me.lucko.luckperms.nukkit.LPNukkitBootstrap";
 
     private final LoaderBootstrap plugin;


### PR DESCRIPTION
Changed the file name luckperms-nukkit.jarinjar to luckperms-pnx.jarinjar
Because the file should be named luckperms-pnx.jarinjar, the following error occurs:
![image](https://github.com/PowerNukkitX-Bundle/LuckPerms/assets/83061703/a487a36d-e7e3-4cdd-9f87-a8f63f21396e)
